### PR TITLE
Symlink executables for `virtpy install`

### DIFF
--- a/src/internal_store.rs
+++ b/src/internal_store.rs
@@ -72,7 +72,7 @@ pub(crate) fn collect_garbage(
                         python_specific_stored_distribs.remove(&hash);
                     }
                     stored_distribs
-                        .save(&proj_dirs)
+                        .save()
                         .wrap_err("failed to save stored distributions")?;
 
                     res.unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -1666,8 +1666,10 @@ fn install_executable_package(
     let executables = distrib.executable_names(proj_dirs)?;
     let exe_dir = virtpy.executables();
     let target_dir = proj_dirs.executables();
-    for exe in executables {
-        // TODO: for windows, we need to link to the .exe files
+    for mut exe in executables {
+        if cfg!(windows) {
+            exe.push_str(".exe");
+        };
         symlink_file(exe_dir.join(&exe), target_dir.join(&exe))?;
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 use camino::{Utf8Path, Utf8PathBuf};
-use eyre::{bail, ensure, eyre, WrapErr};
+use eyre::{ensure, eyre, WrapErr};
 use fs_err::File;
 use itertools::Itertools;
 use python_requirements::Requirement;
@@ -670,12 +670,6 @@ fn _generate_executable(
         hash: FileHash::from_reader(bytes),
         filesize: bytes.len() as u64,
     })
-}
-
-// TODO: remove every use with StoredDistribution::entrypoints
-fn entrypoints(dist_info: &Path) -> Option<Vec<EntryPoint>> {
-    let ini = dist_info.join("entry_points.txt");
-    _entrypoints(&ini)
 }
 
 fn _entrypoints(path: &Path) -> Option<Vec<EntryPoint>> {
@@ -2077,6 +2071,7 @@ trait VirtpyPaths {
         python_path(self.location())
     }
 
+    #[allow(unused)]
     fn dist_info(&self, package: &str) -> EResult<PathBuf> {
         let package = &normalized_distribution_name_for_wheel(package);
         self.dist_infos()
@@ -2885,7 +2880,8 @@ mod test {
 
     #[test]
     fn read_entrypoints() {
-        let entrypoints = entrypoints("test_files/entrypoints.dist-info".as_ref()).unwrap();
+        let entrypoints =
+            _entrypoints("test_files/entrypoints.dist-info/entry_points.txt".as_ref()).unwrap();
         assert_eq!(
             entrypoints,
             &[


### PR DESCRIPTION
Symlinking the executables from the isolated virtpys into the central executable directory that's on the PATH has a few advantages over generating copies of the entrypoint scripts into the executable directory.

1. It works for non-python executables from a wheel's data directory (Related to #2)
2. We can detect what virtpy an executable belongs to just be reading the symlink path.
    That makes deletion easier as well.
3. The functions for installing executables into an isolated virtpy do not need to know about a central executable directory.
    `virtpy install` should build on top of the core of the tool, not be intertwined with it.

~~TODO: On Windows, the executables have `.exe` file endings and so the symlinks need to point at `.exe` paths. This branch doesn't implement that yet.~~