### PR TITLE
fix pip install from folder

### DIFF
--- a/pip_shim/pip/__init__.py
+++ b/pip_shim/pip/__init__.py
@@ -170,7 +170,7 @@ def install_package_from_folder(package_path: str) -> None:
                 "--no-cache-dir",
                 "--wheel-dir",
                 directory,
-                ".venv/src/pendulum/",
+                package_path,
             ],
             check=True,
         )


### PR DESCRIPTION
The path was hardcoded for pendulum, probably a leftover from testing.

The functionality is to support poetry's installs from git repositories. I still need to add a test for this, but I can't right now, because poetry's git installs are broken in poetry v1.1.13. That is unrelated to virtpy. 